### PR TITLE
update_to_v0.8.0_1 (missing setuptools)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - numpy >=1.17
     - pooch >=1.0
     - rasterio >=1.0
-    - setuptools >= 40.4
+    - setuptools >=40.4
     - shapely >=1.6
     - xarray >=0.15
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,20 +9,23 @@ source:
   sha256: b37d9960c94178e88f47a1ac486c705bd9e2c96971739c1234312bff33f7ba48
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
-  build:
+  host:
     - python >=3.6
     - pip
+    - setuptools_scm
+
   run:
     - python >=3.6
     - geopandas >=0.6
     - numpy >=1.17
     - pooch >=1.0
     - rasterio >=1.0
+    - setuptools >= 40.4
     - shapely >=1.6
     - xarray >=0.15
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The version info was not correct with a conda installed regionmask:

```python
In [1]: import regionmask

In [2]: regionmask.__version__
Out[2]: '0.0.0'
```

Maybe because `setuptools_scm` is missing in the build step? In pip it's correct...
